### PR TITLE
Added run script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.swp*
+.selected-mic

--- a/run.sh
+++ b/run.sh
@@ -1,28 +1,40 @@
 #!/bin/bash
 
+if [[ $1 == '' || $1 == '-h' || $1 == '--help' ]]; then
+    echo "usage: $0 -h | --help | -e | --execute | -t | --test | -d | --delete"
+    echo -e "\t-h|--help: prints this help message"
+    echo -e "\t-e|--execute: executes results of speech recognition"
+    echo -e "\t-t|--test: prints results of speech recognition"
+    echo -e "\t-d|--delete: deletes saved microphone selection"
+    exit 0
+fi
+
+if [[ $1 != '-d' && $1 != '--delete' && $1 != '-t' && $1 != '--test' && $1 != '-e' && $1 != '--execute' ]]; then
+    echo "Unknown command '$1'. Run with --help to see usage."
+    exit 1
+fi
+
+if [[ $1 == '-d' || $1 == '--delete' ]]; then
+    rm -f .selected-mic
+    exit 0
+fi
+
 if [[ -f .selected-mic ]]; then
     which=$(cat .selected-mic)
 else
+    echo "No microphone selected..."
     echo "Finding microphones . . ."
     python stream/list-mics.py 2>/dev/null
 
     echo "Use which device?"
     read which
+    echo $which >> .selected-mic
 fi
 
-echo "Selected microphone $which"
+echo "Selected microphone $which."
 
-echo "Which mode? test|save|run"
-
-read mode
-
-if [[ $mode == 'test' ]]; then
-    python stream/mic.py -s silvius-server.voxhub.io -d $which
-elif [[ $mode == 'run' ]]; then
+if [[ $1 == '-e' || $1 == '--execute' ]]; then
     python stream/mic.py -s silvius-server.voxhub.io -d $which | python grammar/main.py
-elif [[ $mode == 'save' ]]; then
-    echo "Choice saved to .selected-mic"
-    echo $which >> .selected-mic
-else
-    echo "Unknown command $mode"
+elif [[ $1 == 't' || $1 == '--test' ]]; then
+    python stream/mic.py -s silvius-server.voxhub.io -d $which
 fi

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ -f .selected-mic ]]; then
+    which=$(cat .selected-mic)
+else
+    echo "Finding microphones . . ."
+    python stream/list-mics.py 2>/dev/null
+
+    echo "Use which device?"
+    read which
+fi
+
+echo "Selected microphone $which"
+
+echo "Which mode? test|save|run"
+
+read mode
+
+if [[ $mode == 'test' ]]; then
+    python stream/mic.py -s silvius-server.voxhub.io -d $which
+elif [[ $mode == 'run' ]]; then
+    python stream/mic.py -s silvius-server.voxhub.io -d $which | python grammar/main.py
+elif [[ $mode == 'save' ]]; then
+    echo "Choice saved to .selected-mic"
+    echo $which >> .selected-mic
+else
+    echo "Unknown command $mode"
+fi

--- a/run.sh
+++ b/run.sh
@@ -35,6 +35,6 @@ echo "Selected microphone $which."
 
 if [[ $1 == '-e' || $1 == '--execute' ]]; then
     python stream/mic.py -s silvius-server.voxhub.io -d $which | python grammar/main.py
-elif [[ $1 == 't' || $1 == '--test' ]]; then
+elif [[ $1 == '-t' || $1 == '--test' ]]; then
     python stream/mic.py -s silvius-server.voxhub.io -d $which
 fi


### PR DESCRIPTION
It's a very simple bash script that makes the process of running Silvius a touch easer. Now, instead of doing the list-mics script, saving the index, etc. manually, the `run.sh` script will do that for you.

Not sure if it's in line with what you want for the repo, but this is basically an enhanced version of the script I use whenever I'm launching silvius myself anyhow, so here you go. Do what you will with it. :-)