### PR TITLE
Silvius on Windows and OS X

### DIFF
--- a/README-windows-mac.md
+++ b/README-windows-mac.md
@@ -1,0 +1,85 @@
+
+Silvius on Windows and Mac
+===========================
+
+Silvius uses the 'xdotool' utility to send keystrokes to the active
+window in your X session. This tool is Linux only; while 'xdotool' is
+available on Windows and OS X, the functionality is reduced compared
+to 'xdotool' on Linux, and on OS X it requires XQuartz to be
+running. On the other hand, each platform has native tools that
+accomplish the same thing:
+
+* On Windows, there's 'NirCmd' (http://www.nirsoft.net/utils/nircmd.html)
+
+* On Mac, there's CLI-Click (https://www.bluem.net/en/projects/cliclick/)
+
+A few modifications were made to Silvius (and the Automator class in
+particular), because these tools have slightly different command-line
+formats.
+
+Additionally, NirCmd (Windows) uses the concept of virtual key codes
+(https://docs.microsoft.com/en-us/windows/desktop/inputdev/virtual-key-codes)
+which are translated into characters differently, depending on your
+keyboard layout. This means that you may have to modify the virtual
+key codes in NirCmdAutomator if you use a different keyboard
+layout. (See the NirCmdAutomator class in automators.py)
+
+
+Mac: Prepare your environment
+-------------------------------
+
+There are two prerequisites we'll need to install in order to be able
+to install all necessary components:
+
+* Homebrew (https://brew.sh)
+
+    We'll use this package manager for mac to install a couple of
+    components.
+
+* PIP
+
+   The package manager for python. Install it by running this command
+   in the Terminal:
+
+   ``sudo easyinstall pip``
+
+Then, we install the components themselves:
+
+``brew install portaudio``
+
+``pip install pyaudio ws4py``
+
+``brew install cliclick``
+
+
+Windows: Prepare your environment
+----------------------------------
+
+On Windows, you'll need to install a few components as well:
+
+* Python 2.7 for Windows (https://www.python.org/downloads/windows/)
+
+* NirCmd (http://www.nirsoft.net/utils/nircmd.html)
+
+Then, install the components:
+
+``pip install pyaudio ws4py``
+
+
+Install Silvius
+================
+
+Clone the git repository to get a local copy:
+
+``git clone https://github.com/dwks/silvius.git``
+
+Upon startup, Silvius will detect the OS it's running on, and select
+the appropriate Automator.
+
+
+Run Silvius
+=============
+
+``python stream/mic.py -s silvius-server.voxhub.io | python grammar/main.py``
+
+

--- a/grammar/automators.py
+++ b/grammar/automators.py
@@ -1,0 +1,271 @@
+# Low-level execution of AST commands using xdotool.
+
+import os, string
+
+
+class Automator:
+    def __init__(self, real = True):
+        self.char_list = []
+        self.real = real
+
+    def add_keystrokes(self, keystrokes):
+        self.char_list.append(keystrokes)
+
+    def execute(self, command):
+        if command == '': return
+
+        print "`%s`" % command
+        if self.real:
+            os.system(command)
+
+    def key(self, k):
+        """ add keystrokes to the list. The first character will be capitalized. """
+        if(len(k) > 1): k = k.capitalize()
+        self.key_nocaps(k)
+
+    # abstract methods
+    def flush(self):
+        """ send the keystroke list in char_list to the OS/keystroke tool """
+        pass
+
+    def raw_key(self, k):
+        """ add a 'raw' keystroke to the list. see parse.py for which
+            keystrokes to support (CoreParser.p_character(), CoreParser.p_editing()) """ 
+        pass
+    
+    def key_movement(self, k):
+        """ add keystrokes to the list for up, down, left, right arrows, and
+            page up/page down. """
+        pass
+
+    def key_nocaps(self, k):
+        """ add keystrokes to the list. the keystrokes are added as is, no
+            modification is done. """
+        pass
+
+    def mod_plus_key(self, mods, k):
+        """ add a keystroke, combined with a modifier (ctrl or alt) """
+        pass
+
+    
+
+class XDoAutomator(Automator):
+
+    def flush(self):
+        if len(self.char_list) == 0: return
+
+        command = '/usr/bin/xdotool' + ' '
+        command += ' '.join(self.char_list)
+        self.execute(command)
+        self.char_list = []
+
+    def raw_key(self, k):
+        if(k == "'"): k = 'apostrophe'
+        elif(k == '.'): k = 'period'
+        elif(k == '-'): k = 'minus'
+        self.add_keystrokes('key ' + k)
+
+    def key_movement(self, k):
+        k = k.capitalize()
+        self.add_keystrokes('key ' + k)
+        
+    def key_nocaps(self, k):
+        self.add_keystrokes('key ' + k)
+
+    def mod_plus_key(self, mods, k):
+        command = 'key '
+        command += '+'.join(mods)
+        if(len(k) > 1 and k != 'plus' and k != 'apostrophe' and k != 'period' and k != 'minus'): k = k.capitalize()
+        command += '+' + k
+        self.add_keystrokes(command)
+
+
+class CLIClickAutomator(Automator):
+
+    def flush(self):
+        if len(self.char_list) == 0: return
+
+        command = 'cliclick' + ' '
+        command += ' '.join(self.char_list)
+        self.execute(command)
+        self.char_list = []
+
+    def transform_key(self, k):
+        lower_k = k.lower()
+        if(lower_k == "apostrophe"):
+            return 't:"\'"' 
+        elif(lower_k == 'quotedbl'):
+            return "t:'\"'"
+        elif (lower_k == 'period'):
+            return "t:'.'"
+        elif(lower_k == 'minus'):
+            return "t:'-'"
+        elif(lower_k == 'equal'):
+            return "t:'='"
+        elif(lower_k == 'colon'):
+            return "t:':'"
+        elif(lower_k == 'semicolon'):
+            return "t:';'"
+        elif(lower_k == 'backspace'):
+            return "kp:delete"
+        elif(lower_k == 'escape'):
+            return "kp:esc"
+        elif(lower_k == 'exclam'):
+            return "t:'!'"
+        elif(lower_k == 'numbersign'):
+            return "t:'#'"
+        elif(lower_k == 'dollar'):
+            return "t:'$'"
+        elif(lower_k == 'percent'):
+            return "t:'%'"
+        elif(lower_k == 'caret'):
+            return "t:'^'"
+        elif(lower_k == 'ampersand'):
+            return "t:'&'"
+        elif(lower_k == 'asterisk'):
+            return "t:'*'"
+        elif(lower_k == 'parenleft'):
+            return "t:'('"            
+        elif(lower_k == 'parenright'):
+            return "t:')'"
+        elif(lower_k == 'underscore'):
+            return "t:'_'"
+        elif(lower_k == 'plus'):
+            return "t:'+'"
+        elif(lower_k == 'backslash'):
+            return "t:'\\'"
+        elif(lower_k == 'slash'):
+            return "t:'/'"
+        elif(lower_k == 'question'):
+            return "t:'?'"
+        elif(lower_k == 'comma'):
+            return "t:','"
+        elif(lower_k == 'space'):
+            return "kp:space"
+        elif(len(lower_k) == 1 and (lower_k[0].isalpha() or lower_k[0].isdigit())):
+            return "t:" + k[0]
+        else:
+            return 'kp:' + k.lower()
+        
+    def raw_key(self, k):
+        self.add_keystrokes(self.transform_key(k))
+
+    def key_nocaps(self, k):
+        self.add_keystrokes('t:'+k)
+
+    def key_movement(self, k):
+        if "page" in k:
+            self.add_keystrokes('kp:page-' + k[4:].lower())
+        else:
+            self.add_keystrokes('kp:arrow-' + k.lower())
+            
+    def mod_plus_key(self, mods, k):
+        command = "w:10 kd:"
+        command += ','.join(mods)
+        if(len(k) > 1 and k != 'plus' and k != 'apostrophe' and k != 'period' and k != 'minus'): k = k.capitalize()
+        command += " "
+        command += self.transform_key(k)
+        command += " "
+        command += "ku:"
+        command += ','.join(mods)
+        self.add_keystrokes(command)
+
+
+class NirCmdAutomator(Automator):
+
+    # nircmd.exe transformations used here are keyboard layout specific;
+    # they rely on virtual key codes
+    # (https://docs.microsoft.com/en-us/windows/desktop/inputdev/virtual-key-codes)
+    # the character that actually comes out is dependent on the keyoard
+    # layout you have configured.
+    keymap = 'english_us' #'belgian'
+    keymaps = {
+        'escape':    { 'belgian': 'esc',
+                       'english_us': 'esc' },
+        'colon':     { 'belgian': '0xBF',
+                       'english_us': 'shift+0xba' },
+        'semicolon': { 'belgian': '0xBE',
+                       'english_us': '0xba' },
+        'apostrophe':{ 'belgian': '0x34',
+                       'english_us': '0xde' },
+        'quotedbl':  { 'belgian': '0x33',
+                       'english_us': 'shift+0xde' },
+        'period':    { 'belgian': 'shift+0xBE',
+                       'english_us': '0xBE' },
+        'equal':     { 'belgian': '0xbb',
+                       'english_us': '0xbb' },
+        'space':     { 'belgian': 'spc',
+                       'english_us': 'spc' },
+        'exclam':    { 'belgian': '0x38',
+                       'english_us': 'shift+0x31' },
+        'numbersign':{ 'belgian': 'ctrl+alt+0x33',
+                       'english_us': 'shift+0x33' },
+        'dollar':    { 'belgian': '0xba',
+                       'english_us': 'shift+0x34' },
+        'percent':   { 'belgian': 'shift+0xC0',
+                       'english_us': 'shift+0x35' },
+        'caret':     { 'belgian': 'ctrl+alt+0x36',
+                       'english_us': 'shift+0x36' },
+        'ampersand': { 'belgian': '0x31',
+                       'english_us': 'shift+0x37' },
+        'asterisk':  { 'belgian': 'shift+0xBA',
+                       'english_us': 'shift+0x38' },
+        'parenleft': { 'belgian': '0x35',
+                       'english_us': 'shift+0x39' },
+        'parenright':{ 'belgian': '0xdb',
+                       'english_us': 'shift+0x30' },
+        'minus':     { 'belgian': 'minus',
+                       'english_us': 'minus' },
+        'underscore':{ 'belgian': 'shift+0xBD',
+                       'english_us': 'shift+0xBD' },
+        'plus':      { 'belgian': 'shift+0xBB',
+                       'english_us': 'shift+0xBB' },
+        'backslash': { 'belgian': 'ctrl+alt+0xe2',
+                       'english_us': '0xe2' },
+        'slash':     { 'belgian': 'shift+0xBF',
+                       'english_us': '0xBF' },
+        'question':  { 'belgian': 'shift+0xBC',
+                       'english_us': 'shift+0xBf' },
+        'comma':     { 'belgian': '0xbc',
+                       'english_us': '0xbc' },
+        'backspace': { 'belgian': 'backspace',
+                       'english_us': 'backspace' },
+        'return':    { 'belgian': '0x0d',
+                       'english_us': '0x0d' },
+        'tab':       { 'belgian': 'tab',
+                       'english_us': 'tab' },
+    }
+
+    def flush(self):
+        if len(self.char_list) == 0: return
+
+        command = 'C:\\Tools\\nircmd-x64\\nircmd.exe sendkeypress' + ' '
+        command += ' '.join(self.char_list)
+        self.execute(command)
+        self.char_list = []
+
+    def raw_key(self, k):
+        if k.lower() in self.keymaps:
+            self.add_keystrokes(
+                self.keymaps[k.lower()][self.keymap].lower()
+            )
+        else:
+            self.add_keystrokes(k)
+
+    def key_movement(self, k):
+        self.add_keystrokes(k)
+
+    def key_nocaps(self, k):
+        if k in string.ascii_uppercase:
+            k = "shift+" + k
+        self.add_keystrokes(k)
+
+    def mod_plus_key(self, mods, k):
+        if (type(k) is not str):
+            k = k.type
+        command = ""
+        command += '+'.join(mods)
+        if(len(k) > 1 and k != 'plus' and k != 'apostrophe' and k != 'period' and k != 'minus'): k = k.capitalize()
+        command += "+"
+        command += k
+        self.key_nocaps(command)

--- a/tests/run_tests_linux.sh
+++ b/tests/run_tests_linux.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+python ../grammar/main.py testcases.txt > test_out.txt
+grep -e "xdotool" -e "Error:" test_out.txt > commands.txt
+diff commands.txt testcases_expected_linux.txt
+rm test_out.txt commands.txt

--- a/tests/run_tests_mac.sh
+++ b/tests/run_tests_mac.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+python ../grammar/main.py testcases.txt > test_out.txt
+grep -e "cliclick" -e "Error:" test_out.txt > commands.txt
+diff commands.txt testcases_expected_mac.txt
+rm test_out.txt commands.txt

--- a/tests/run_tests_windows.bat
+++ b/tests/run_tests_windows.bat
@@ -1,0 +1,9 @@
+@echo off
+rem Run tests generating nircmd command lines.
+rem For this script, no output is good. diff will output
+rem all lines that are different.
+rem
+python ../grammar/main.py testcases.txt > test_out.txt
+grep -e "nircmd" -e "Error:" test_out.txt > commands.txt
+diff --strip-trailing-cr commands.txt testcases_expected_windows_englishuskeymap.txt
+rm test_out.txt commands.txt

--- a/tests/testcases.txt
+++ b/tests/testcases.txt
@@ -1,0 +1,40 @@
+up
+down two
+number nine
+arch bravo charlie delta echo fox golf
+act
+colon
+semicolon
+single quote
+double quote
+equal
+space
+tab
+bang
+hash
+dollar
+percent
+carrot
+ampersand
+star
+late
+rate
+minus
+underscore
+plus
+backslash
+dot
+dit
+slash
+question
+comma
+sky arch
+word yesterday
+phrase it is dark outside
+sentence it is dark outside
+charlie delta space dot dot slap
+scratch scratch scratch
+scratch three
+control expert uniform
+control expert number one
+control alt zulu

--- a/tests/testcases.txt
+++ b/tests/testcases.txt
@@ -38,3 +38,5 @@ scratch three
 control expert uniform
 control expert number one
 control alt zulu
+control space
+control left

--- a/tests/testcases_expected_linux.txt
+++ b/tests/testcases_expected_linux.txt
@@ -1,5 +1,5 @@
-`/usr/bin/xdotool key up`
-`/usr/bin/xdotool key down key up`
+`/usr/bin/xdotool key Up`
+`/usr/bin/xdotool key Down key Down`
 `/usr/bin/xdotool key 9`
 `/usr/bin/xdotool key a key b key c key d key e key f key g`
 `/usr/bin/xdotool key Escape`
@@ -38,3 +38,5 @@
 `/usr/bin/xdotool key ctrl+x key u`
 `/usr/bin/xdotool key ctrl+x key 1`
 `/usr/bin/xdotool key ctrl+alt+z`
+`/usr/bin/xdotool key ctrl+space`
+`/usr/bin/xdotool key ctrl+Left`

--- a/tests/testcases_expected_linux.txt
+++ b/tests/testcases_expected_linux.txt
@@ -1,0 +1,40 @@
+`/usr/bin/xdotool key up`
+`/usr/bin/xdotool key down key up`
+`/usr/bin/xdotool key 9`
+`/usr/bin/xdotool key a key b key c key d key e key f key g`
+`/usr/bin/xdotool key Escape`
+`/usr/bin/xdotool key colon`
+`/usr/bin/xdotool key semicolon`
+`/usr/bin/xdotool key apostrophe`
+`/usr/bin/xdotool key quotedbl`
+`/usr/bin/xdotool key equal`
+`/usr/bin/xdotool key space`
+`/usr/bin/xdotool key Tab`
+`/usr/bin/xdotool key exclam`
+`/usr/bin/xdotool key numbersign`
+`/usr/bin/xdotool key dollar`
+`/usr/bin/xdotool key percent`
+`/usr/bin/xdotool key caret`
+`/usr/bin/xdotool key ampersand`
+`/usr/bin/xdotool key asterisk`
+`/usr/bin/xdotool key parenleft`
+`/usr/bin/xdotool key parenright`
+`/usr/bin/xdotool key minus`
+`/usr/bin/xdotool key underscore`
+`/usr/bin/xdotool key plus`
+`/usr/bin/xdotool key backslash`
+`/usr/bin/xdotool key period`
+`/usr/bin/xdotool key period`
+`/usr/bin/xdotool key slash`
+`/usr/bin/xdotool key question`
+`/usr/bin/xdotool key comma`
+`/usr/bin/xdotool key A`
+`/usr/bin/xdotool key y key e key s key t key e key r key d key a key y`
+`/usr/bin/xdotool key i key t key space key i key s key space key d key a key r key k key space key o key u key t key s key i key d key e`
+`/usr/bin/xdotool key I key t key space key i key s key space key d key a key r key k key space key o key u key t key s key i key d key e`
+`/usr/bin/xdotool key c key d key space key period key period key Return`
+`/usr/bin/xdotool key BackSpace key BackSpace key BackSpace`
+`/usr/bin/xdotool key BackSpace key BackSpace key BackSpace`
+`/usr/bin/xdotool key ctrl+x key u`
+`/usr/bin/xdotool key ctrl+x key 1`
+`/usr/bin/xdotool key ctrl+alt+z`

--- a/tests/testcases_expected_mac.txt
+++ b/tests/testcases_expected_mac.txt
@@ -38,3 +38,5 @@
 `cliclick w:10 kd:ctrl t:x ku:ctrl t:u`
 `cliclick w:10 kd:ctrl t:x ku:ctrl t:1`
 `cliclick w:10 kd:ctrl,alt t:z ku:ctrl,alt`
+`cliclick w:10 kd:ctrl kp:space ku:ctrl`
+`cliclick w:10 kd:ctrl kp:arrow-left ku:ctrl`

--- a/tests/testcases_expected_mac.txt
+++ b/tests/testcases_expected_mac.txt
@@ -1,0 +1,40 @@
+`cliclick kp:arrow-up`
+`cliclick kp:arrow-down kp:arrow-down`
+`cliclick t:9`
+`cliclick t:a t:b t:c t:d t:e t:f t:g`
+`cliclick kp:esc`
+`cliclick t:':'`
+`cliclick t:';'`
+`cliclick t:"'"`
+`cliclick t:'"'`
+`cliclick t:'='`
+`cliclick kp:space`
+`cliclick kp:tab`
+`cliclick t:'!'`
+`cliclick t:'#'`
+`cliclick t:'$'`
+`cliclick t:'%'`
+`cliclick t:'^'`
+`cliclick t:'&'`
+`cliclick t:'*'`
+`cliclick t:'('`
+`cliclick t:')'`
+`cliclick t:'-'`
+`cliclick t:'_'`
+`cliclick t:'+'`
+`cliclick t:'\'`
+`cliclick t:'.'`
+`cliclick t:'.'`
+`cliclick t:'/'`
+`cliclick t:'?'`
+`cliclick t:','`
+`cliclick t:A`
+`cliclick t:y t:e t:s t:t t:e t:r t:d t:a t:y`
+`cliclick t:i t:t kp:space t:i t:s kp:space t:d t:a t:r t:k kp:space t:o t:u t:t t:s t:i t:d t:e`
+`cliclick t:I t:t kp:space t:i t:s kp:space t:d t:a t:r t:k kp:space t:o t:u t:t t:s t:i t:d t:e`
+`cliclick t:c t:d kp:space t:'.' t:'.' kp:return`
+`cliclick kp:delete kp:delete kp:delete`
+`cliclick kp:delete kp:delete kp:delete`
+`cliclick w:10 kd:ctrl t:x ku:ctrl t:u`
+`cliclick w:10 kd:ctrl t:x ku:ctrl t:1`
+`cliclick w:10 kd:ctrl,alt t:z ku:ctrl,alt`

--- a/tests/testcases_expected_windows_belgiankeymap.txt
+++ b/tests/testcases_expected_windows_belgiankeymap.txt
@@ -38,3 +38,5 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x u`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x 1`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+spc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`

--- a/tests/testcases_expected_windows_belgiankeymap.txt
+++ b/tests/testcases_expected_windows_belgiankeymap.txt
@@ -1,0 +1,40 @@
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress up`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress down down`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 9`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress a b c d e f g`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress esc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbf`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbe`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0x34`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0x33`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbb`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress spc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress tab`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0x38`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+0x33`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xba`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xc0`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+0x36`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0x31`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xba`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0x35`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xdb`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress minus`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbd`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbb`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+0xe2`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbe`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbe`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbf`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+A`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress y e s t e r d a y`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress i t spc i s spc d a r k spc o u t s i d e`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress I t spc i s spc d a r k spc o u t s i d e`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress c d spc shift+0xbe shift+0xbe 0x0d`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress backspace backspace backspace`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress backspace backspace backspace`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x u`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x 1`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`

--- a/tests/testcases_expected_windows_englishuskeymap.txt
+++ b/tests/testcases_expected_windows_englishuskeymap.txt
@@ -1,0 +1,40 @@
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress up`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress down down`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 9`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress a b c d e f g`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress esc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xba`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xba`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xde`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xde`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbb`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress spc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress tab`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x31`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x33`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x34`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x35`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x36`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x37`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x38`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x39`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0x30`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress minus`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbd`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbb`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xe2`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbe`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbe`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbf`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+0xbf`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 0xbc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress shift+A`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress y e s t e r d a y`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress i t spc i s spc d a r k spc o u t s i d e`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress I t spc i s spc d a r k spc o u t s i d e`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress c d spc 0xbe 0xbe 0x0d`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress backspace backspace backspace`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress backspace backspace backspace`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x u`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x 1`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`

--- a/tests/testcases_expected_windows_englishuskeymap.txt
+++ b/tests/testcases_expected_windows_englishuskeymap.txt
@@ -38,3 +38,5 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x u`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+x 1`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+spc`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`


### PR DESCRIPTION
This is an adaptation to be able to run Silvius on Windows and OS X, in addition to Linux. 

On non-Linux platforms a native tool is used instead of xdotool (nircmd and cliclick, respectively). The most important changes were to:

- extract the Automator class into its own file, and
- to provide per-platform specializations of the Automator.

There is also a test script to be able to run regression tests after making changes.

Looking at the issue list, this seems to address issues 8 (Mac support), 10 (multiplatform) and 22 (modifier+movement crashes the client).