### PR TITLE
use map in CLIClickAutomator.transform_key; numbers fix

### DIFF
--- a/grammar/automators.py
+++ b/grammar/automators.py
@@ -84,6 +84,38 @@ class XDoAutomator(Automator):
 
 class CLIClickAutomator(Automator):
 
+    keymap = {
+        "apostrophe": 't:"\'"',
+        'quotedbl'  : "t:'\"'",
+        'period'    : "t:'.'",
+        'minus'     : "t:'-'",
+        'equal'     : "t:'='",
+        'colon'     : "t:':'",
+        'semicolon' : "t:';'",
+        'backspace' : "kp:delete",
+        'escape'    : "kp:esc",
+        'exclam'    : "t:'!'",
+        'numbersign': "t:'#'",
+        'dollar'    : "t:'$'",
+        'percent'   : "t:'%'",
+        'caret'     : "t:'^'",
+        'ampersand' : "t:'&'",
+        'asterisk'  : "t:'*'",
+        'parenleft' : "t:'('",
+        'parenright': "t:')'",
+        'underscore': "t:'_'",
+        'plus'      : "t:'+'",
+        'backslash' : "t:'\\'",
+        'slash'     : "t:'/'",
+        'question'  : "t:'?'",
+        'comma'     : "t:','",
+        'space'     : "kp:space",
+        'left'      : "kp:arrow-left",
+        'right'     : "kp:arrow-right",
+        'up'        : "kp:arrow-up",
+        'down'      : "kp:arrow-down"
+    }
+
     def flush(self):
         if len(self.char_list) == 0: return
 
@@ -94,64 +126,8 @@ class CLIClickAutomator(Automator):
 
     def transform_key(self, k):
         lower_k = k.lower()
-        if(lower_k == "apostrophe"):
-            return 't:"\'"' 
-        elif(lower_k == 'quotedbl'):
-            return "t:'\"'"
-        elif (lower_k == 'period'):
-            return "t:'.'"
-        elif(lower_k == 'minus'):
-            return "t:'-'"
-        elif(lower_k == 'equal'):
-            return "t:'='"
-        elif(lower_k == 'colon'):
-            return "t:':'"
-        elif(lower_k == 'semicolon'):
-            return "t:';'"
-        elif(lower_k == 'backspace'):
-            return "kp:delete"
-        elif(lower_k == 'escape'):
-            return "kp:esc"
-        elif(lower_k == 'exclam'):
-            return "t:'!'"
-        elif(lower_k == 'numbersign'):
-            return "t:'#'"
-        elif(lower_k == 'dollar'):
-            return "t:'$'"
-        elif(lower_k == 'percent'):
-            return "t:'%'"
-        elif(lower_k == 'caret'):
-            return "t:'^'"
-        elif(lower_k == 'ampersand'):
-            return "t:'&'"
-        elif(lower_k == 'asterisk'):
-            return "t:'*'"
-        elif(lower_k == 'parenleft'):
-            return "t:'('"            
-        elif(lower_k == 'parenright'):
-            return "t:')'"
-        elif(lower_k == 'underscore'):
-            return "t:'_'"
-        elif(lower_k == 'plus'):
-            return "t:'+'"
-        elif(lower_k == 'backslash'):
-            return "t:'\\'"
-        elif(lower_k == 'slash'):
-            return "t:'/'"
-        elif(lower_k == 'question'):
-            return "t:'?'"
-        elif(lower_k == 'comma'):
-            return "t:','"
-        elif(lower_k == 'space'):
-            return "kp:space"
-        elif(lower_k == 'left'):
-            return "kp:arrow-left"
-        elif(lower_k == 'right'):
-            return "kp:arrow-right"
-        elif(lower_k == 'up'):
-            return "kp:arrow-up"
-        elif(lower_k == 'down'):
-            return "kp:arrow-down"
+        if lower_k in self.keymap:
+            return self.keymap[lower_k]
         elif(len(lower_k) == 1 and (lower_k[0].isalpha() or lower_k[0].isdigit())):
             return "t:" + k[0]
         else:

--- a/grammar/parse.py
+++ b/grammar/parse.py
@@ -100,7 +100,7 @@ class CoreParser(GenericParser):
             number_rule ::= number million_number_set
             number_rule ::= number billion_number_set
         '''
-        return AST('char', [ str(args[1]) ])
+        return AST('sequence', [ str(args[1]) ])
     def p_number_set(self, args):
         '''
             number_set ::= _firstnumbers

--- a/tests/testcases.txt
+++ b/tests/testcases.txt
@@ -40,3 +40,5 @@ control expert number one
 control alt zulu
 control space
 control left
+number twenty five
+number four hundred two thousand eight hundred fifteen

--- a/tests/testcases_expected_linux.txt
+++ b/tests/testcases_expected_linux.txt
@@ -40,3 +40,5 @@
 `/usr/bin/xdotool key ctrl+alt+z`
 `/usr/bin/xdotool key ctrl+space`
 `/usr/bin/xdotool key ctrl+Left`
+`/usr/bin/xdotool key 2 key 5`
+`/usr/bin/xdotool key 4 key 0 key 2 key 8 key 1 key 5`

--- a/tests/testcases_expected_mac.txt
+++ b/tests/testcases_expected_mac.txt
@@ -40,3 +40,5 @@
 `cliclick w:10 kd:ctrl,alt t:z ku:ctrl,alt`
 `cliclick w:10 kd:ctrl kp:space ku:ctrl`
 `cliclick w:10 kd:ctrl kp:arrow-left ku:ctrl`
+`cliclick t:2 t:5`
+`cliclick t:4 t:0 t:2 t:8 t:1 t:5`

--- a/tests/testcases_expected_windows_belgiankeymap.txt
+++ b/tests/testcases_expected_windows_belgiankeymap.txt
@@ -40,3 +40,5 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+spc`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`

--- a/tests/testcases_expected_windows_englishuskeymap.txt
+++ b/tests/testcases_expected_windows_englishuskeymap.txt
@@ -40,3 +40,5 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+alt+z`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+spc`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`


### PR DESCRIPTION
I agree with your comment that CLIClickAutomator should use a map; commit 86f30c8 implements this.

It seems there is an issue with the recently merged "Support numbers..." commit. The numbers are composed correctly, but e.g. "twenty five" outputs as "xdotool key 25" instead of "xdotool 2 5". Changing the AST node to "sequence" (from "char") fixes this (commit effd698 implements this.