### PR TITLE
Automatically add rules for all terminals to specific, annotated rules.

### DIFF
--- a/grammar/lm.py
+++ b/grammar/lm.py
@@ -109,24 +109,16 @@ def make_lm(rules, visited, which, prefix):
                 print prefix, t
                 new_prefix.append(t)
 
-def get_terminals(parser):
-    visited = {}
-    terminals = []
-    find_terminals(parser.rules, visited, 'START', terminals)
-    keywords = set(terminals)
-    return sorted(keywords)
-
 if __name__ == '__main__':
     import sys
     parser = SingleInputParser()
     #for rule in parser.rules:
     #    print rule, parser.rules[rule]
 
-    visited = {}
+    #visited = {}
     #make_lm(parser.rules, visited, 'START', [])
-    terminals = []
-    find_terminals(parser.rules, visited, 'START', terminals)
-    #print terminals
+
+    terminals = parser.terminals
 
     visited = {}
     find_sequences(parser.rules, visited, 'START')

--- a/grammar/main.py
+++ b/grammar/main.py
@@ -1,6 +1,6 @@
 # Main file. Parse new commands from stdin until EOF.
 
-from scan import find_keywords
+from scan import install_keywords
 from scan import scan
 from parse import parse
 from parse import GrammaticalError
@@ -16,14 +16,8 @@ if __name__ == '__main__':
     else:
         f = sys.stdin
 
-    # The parser is instantiated twice: once to allow
-    # the collection of terminals from the instantiated
-    # parser (in find_keywords), and then again, augmented
-    # with additional rules, created automatically from the
-    # set of terminals.
     parser = SingleInputParser()
-    find_keywords(parser)  # init lexer
-    parser = SingleInputParser() 
+    install_keywords(parser)  # init lexer
 
     while True:
         line = f.readline()

--- a/grammar/main.py
+++ b/grammar/main.py
@@ -16,8 +16,14 @@ if __name__ == '__main__':
     else:
         f = sys.stdin
 
+    # The parser is instantiated twice: once to allow
+    # the collection of terminals from the instantiated
+    # parser (in find_keywords), and then again, augmented
+    # with additional rules, created automatically from the
+    # set of terminals.
     parser = SingleInputParser()
     find_keywords(parser)  # init lexer
+    parser = SingleInputParser() 
 
     while True:
         line = f.readline()

--- a/grammar/scan.py
+++ b/grammar/scan.py
@@ -1,11 +1,8 @@
 # Lexer that produces a sequence of tokens (keywords + ANY).
 
-import re
-from lm import get_terminals
-
-def find_keywords(parser):
+def install_keywords(parser):
     global keywords
-    keywords = get_terminals(parser)
+    keywords = parser.terminals
 
 class Token:
     def __init__(self, type, wordno=-1, extra=''):

--- a/tests/testcases.txt
+++ b/tests/testcases.txt
@@ -42,3 +42,4 @@ control space
 control left
 number twenty five
 number four hundred two thousand eight hundred fifteen
+phrase window sentence phrase

--- a/tests/testcases.txt
+++ b/tests/testcases.txt
@@ -43,3 +43,4 @@ control left
 number twenty five
 number four hundred two thousand eight hundred fifteen
 phrase window sentence phrase
+sentence hello there comma space phrase how are you question

--- a/tests/testcases_expected_linux.txt
+++ b/tests/testcases_expected_linux.txt
@@ -43,3 +43,4 @@
 `/usr/bin/xdotool key 2 key 5`
 `/usr/bin/xdotool key 4 key 0 key 2 key 8 key 1 key 5`
 `/usr/bin/xdotool key w key i key n key d key o key w key space key s key e key n key t key e key n key c key e key space key p key h key r key a key s key e`
+`/usr/bin/xdotool key H key e key l key l key o key space key t key h key e key r key e key comma key space key h key o key w key space key a key r key e key space key y key o key u key question`

--- a/tests/testcases_expected_linux.txt
+++ b/tests/testcases_expected_linux.txt
@@ -42,3 +42,4 @@
 `/usr/bin/xdotool key ctrl+Left`
 `/usr/bin/xdotool key 2 key 5`
 `/usr/bin/xdotool key 4 key 0 key 2 key 8 key 1 key 5`
+`/usr/bin/xdotool key w key i key n key d key o key w key space key s key e key n key t key e key n key c key e key space key p key h key r key a key s key e`

--- a/tests/testcases_expected_mac.txt
+++ b/tests/testcases_expected_mac.txt
@@ -43,3 +43,4 @@
 `cliclick t:2 t:5`
 `cliclick t:4 t:0 t:2 t:8 t:1 t:5`
 `cliclick t:w t:i t:n t:d t:o t:w kp:space t:s t:e t:n t:t t:e t:n t:c t:e kp:space t:p t:h t:r t:a t:s t:e`
+`cliclick t:H t:e t:l t:l t:o kp:space t:t t:h t:e t:r t:e t:',' kp:space t:h t:o t:w kp:space t:a t:r t:e kp:space t:y t:o t:u t:'?'`

--- a/tests/testcases_expected_mac.txt
+++ b/tests/testcases_expected_mac.txt
@@ -42,3 +42,4 @@
 `cliclick w:10 kd:ctrl kp:arrow-left ku:ctrl`
 `cliclick t:2 t:5`
 `cliclick t:4 t:0 t:2 t:8 t:1 t:5`
+`cliclick t:w t:i t:n t:d t:o t:w kp:space t:s t:e t:n t:t t:e t:n t:c t:e kp:space t:p t:h t:r t:a t:s t:e`

--- a/tests/testcases_expected_windows_belgiankeymap.txt
+++ b/tests/testcases_expected_windows_belgiankeymap.txt
@@ -43,3 +43,4 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress w i n d o w spc s e n t e n c e spc p h r a s e`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress H e l l o spc t h e r e 0xbc spc h o w spc a r e spc y o u shift+0xbc`

--- a/tests/testcases_expected_windows_belgiankeymap.txt
+++ b/tests/testcases_expected_windows_belgiankeymap.txt
@@ -42,3 +42,4 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress w i n d o w spc s e n t e n c e spc p h r a s e`

--- a/tests/testcases_expected_windows_englishuskeymap.txt
+++ b/tests/testcases_expected_windows_englishuskeymap.txt
@@ -43,4 +43,4 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress w i n d o w spc s e n t e n c e spc p h r a s e`
-
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress H e l l o spc t h e r e 0xbc spc h o w spc a r e spc y o u shift+0xbf`

--- a/tests/testcases_expected_windows_englishuskeymap.txt
+++ b/tests/testcases_expected_windows_englishuskeymap.txt
@@ -42,3 +42,5 @@
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress ctrl+left`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 2 5`
 `C:\Tools\nircmd-x64\nircmd.exe sendkeypress 4 0 2 8 1 5`
+`C:\Tools\nircmd-x64\nircmd.exe sendkeypress w i n d o w spc s e n t e n c e spc p h r a s e`
+


### PR DESCRIPTION
Words used as terminals in rules don't match the ANY token type, which makes them unusable in "plain English" contexts ("word", "phrase", "sentence"). This becomes a problem when the number of rules increases, and more and more words become "reserved" as tokens. This limitation can be overcome by adding explicit rules, as was already done for the numbers "one", "two" etc in the "raw_word" rule.

To remove the tedium of adding these rules, the commit in this PR adds some logic to handle this automatically.

Because spark uses docstrings to specify rules, and docstrings cannot be appended to at runtime, a function decorator is used. Additionally, collecting the tokens is done most easily on an already-instantiated parser (the implementation for this was already present, too). Finally, it was not clear to me if it is possible to instruct spark to revisit the docstrings and regenerate its set of rules. 

The easiest way to work with the docstring limitation was to add a step to the setup process:

1. instantiate parser
2. collect keywords 
3. instantiate parser again, augmented with rules auto-generated for the keyword list collected in 2. (the parser instantiated in 1. is discarded.)

(issue #19 describes this issue as well.)